### PR TITLE
progress confirm ask add default true

### DIFF
--- a/mac_cleanup/progress.py
+++ b/mac_cleanup/progress.py
@@ -67,6 +67,7 @@ class _ProgressBar:
             choices=choices,
             show_default=show_default,
             show_choices=show_choices,
+            default=True,
         )
 
         # Clear printed stuff

--- a/mac_cleanup/progress.py
+++ b/mac_cleanup/progress.py
@@ -40,6 +40,7 @@ class _ProgressBar:
         choices: Optional[list[str]] = None,
         show_default: bool = True,
         show_choices: bool = True,
+        default: bool = True,
     ) -> bool:
         """
         Stops progress bar to show prompt to user.
@@ -50,6 +51,7 @@ class _ProgressBar:
         :param choices: A list of valid choices. Defaults to None.
         :param show_default: Show default in prompt. Defaults to True.
         :param show_choices: Show choices in prompt. Defaults to True.
+        :param default: Default value in prompt.
         :return: True on successful prompt
         """
 
@@ -67,7 +69,7 @@ class _ProgressBar:
             choices=choices,
             show_default=show_default,
             show_choices=show_choices,
-            default=True,
+            default=default,
         )
 
         # Clear printed stuff


### PR DESCRIPTION
To clean up the process, you need to manually enter y every time, which is very cumbersome, so the function of default true is added
<img width="623" alt="image" src="https://github.com/mac-cleanup/mac-cleanup-py/assets/37658262/8833134e-2f9b-4342-8d64-d3ea3112500f">
