### PR TITLE
Use Python natively and drop awk from sources

### DIFF
--- a/mac_cleanup/main.py
+++ b/mac_cleanup/main.py
@@ -17,8 +17,8 @@ class EntryPoint:
     def count_free_space() -> float:
         """Get current free space."""
 
-        s_fs = statvfs("/")
-        return float(s_fs.f_bavail * s_fs.f_frsize)
+        stat = statvfs("/")
+        return float(stat.f_bavail * stat.f_frsize)
 
     def cleanup(self) -> None:
         """Launch cleanup and print results."""

--- a/mac_cleanup/main.py
+++ b/mac_cleanup/main.py
@@ -18,7 +18,7 @@ class EntryPoint:
         """Get current free space."""
 
         s_fs = statvfs("/")
-        return float(s_fs.f_bavail * s_fs.f_frsize / s_fs.f_bsize)
+        return float(s_fs.f_bavail * s_fs.f_frsize)
 
     def cleanup(self) -> None:
         """Launch cleanup and print results."""
@@ -38,7 +38,7 @@ class EntryPoint:
 
         # Print results
         print_panel(
-            text=f"Removed - [success]{bytes_to_human((free_space_after - free_space_before) * 1024)}",
+            text=f"Removed - [success]{bytes_to_human(free_space_after - free_space_before)}",
             title="[info]Success",
         )
 

--- a/mac_cleanup/main.py
+++ b/mac_cleanup/main.py
@@ -1,3 +1,4 @@
+from os import statvfs
 from pathlib import Path
 
 from mac_cleanup.config import Config
@@ -5,7 +6,7 @@ from mac_cleanup.console import console, print_panel
 from mac_cleanup.core import _Collector
 from mac_cleanup.error_handling import catch_exception
 from mac_cleanup.parser import args
-from mac_cleanup.utils import bytes_to_human, cmd
+from mac_cleanup.utils import bytes_to_human
 
 
 class EntryPoint:
@@ -16,7 +17,8 @@ class EntryPoint:
     def count_free_space() -> float:
         """Get current free space."""
 
-        return float(cmd("df / | tail -1 | awk '{print $4}'"))
+        s_fs = statvfs("/")
+        return float(s_fs.f_bavail * s_fs.f_frsize / s_fs.f_bsize)
 
     def cleanup(self) -> None:
         """Launch cleanup and print results."""

--- a/mac_cleanup/utils.py
+++ b/mac_cleanup/utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional, cast
 
 from beartype import beartype  # pyright: ignore [reportUnknownVariableType]
+from xattr import xattr  # pyright: ignore [reportMissingTypeStubs]
 
 
 @beartype
@@ -95,7 +96,10 @@ def check_deletable(path: Path | str) -> bool:
     # Returns False if path startswith anything from SIP list or in custom list
     if any(path_posix.startswith(protected_path) for protected_path in list(map(expanduser, sip_list + user_list))):
         return False
-    return "restricted" not in cmd(f"ls -lo {path_posix} | awk '{{print $3, $4}}'")
+
+    path_posix = path_.expanduser().as_posix()
+
+    return "com.apple.rootless" not in xattr(path_posix).keys()
 
 
 @beartype

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ attrs = "^23.1.0"
 inquirer = "^3.1.3"
 toml = "^0.10.2"
 beartype = "^0.14.1"
+xattr = "^1.1.0"
 
 [tool.poetry.scripts]
 mac-cleanup = "mac_cleanup:main"


### PR DESCRIPTION
Use Python natively and drop awk from sources
---

Description
---

* `statvfs` to replace parsing `df /` output
* A third party `xattr` module to deal with "restricted" SIP attributes instead of wrongly-used `ls`. Luckily, there is no issue opened for the case.

Type of Change
---

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement

How Has This Been Tested?
---

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] poetry run tox on Python 3.10/3.11
- [x] Functional test on local machine 

Checklist
---

- [x] My code follows the style guidelines of this project
- [x] My changes generate no new warnings (pyright: ignore [reportMissingTypeStubs])

Screenshots
---

_Attach screenshots or screen recordings of the changes, if any._

Additional Context
---

_Add any other context or information about the pull request here._
