### PR TITLE
feat: Added new default modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@
 ## 🧹 Python cleanup script for macOS
 
 **mac-cleanup-py** is a powerful cleanup script for macOS.\
-This project is a rewrite of the original [mac-cleanup-sh](https://github.com/mac-cleanup/mac-cleanup-sh) rewritten in Python. 
-
+This project is a rewrite of the original [mac-cleanup-sh](https://github.com/mac-cleanup/mac-cleanup-sh) rewritten in Python.
 
 ## 🚀 Features
 
 **mac-cleanup-py** helps you:
 
-1. Empty Trash 
-2. Delete unnecessary logs & files 
+1. Empty Trash
+2. Delete unnecessary logs & files
 3. Clear cache
 
 ![mac-cleanup-demo](https://user-images.githubusercontent.com/44712637/231780851-d2197255-e24e-46ba-8355-42bcf588376d.gif)
@@ -28,48 +27,50 @@ This project is a rewrite of the original [mac-cleanup-sh](https://github.com/ma
 
   </br>
 
-  - `adobe` - Clears **Adobe** cache files
-  - `android` - Clears **Android** caches
-  - `brew` - Clears **Homebrew** cache
-  - `bun` - Clears **Bun** cache
-  - `conan` - Clears **Conan** cache
-  - `cacher` - Clears **Cacher** logs
-  - `chrome` - Clears **Google Chrome** cache
-  - `composer` - Clears **composer** cache
-  - `dns_cache` - Clears **DNS** cache
-  - `docker` - Cleanup dangling **Docker** Images and stopped containers
-  - `dropbox` - Clears **Dropbox** cache
-  - `gem` - Cleanup any old versions of **Gems**
-  - `go` - Clears **Go** cache
-  - `google_drive` - Clears **Google Drive** caches
-  - `gradle` - Clears **Gradle** caches
-  - `inactive_memory` - Purge **Inactive Memory**
-  - `ios_apps` - Cleanup **iOS Applications**
-  - `ios_backups` - Removes **iOS Device Backups**
-  - `java_cache` - Removes **Java head dumps** from home directory
-  - `jetbrains` - Removes logs from **PhpStorm**, **PyCharm** etc
-  - `kite` - Deletes **Kite** logs
-  - `lunarclient` - Removes **Lunar Client** logs and cache
-  - `microsoft_teams` - Remove **Microsoft Teams** logs and cache
-  - `minecraft` - Remove **Minecraft** logs and cache
-  - `npm` - Cleanup **npm** Cache
-  - `pnpm` - Cleanup **pnpm** Cache
-  - `pod` - Cleanup **CocoaPods** Cache Files
-  - `poetry` - Clears **Poetry** cache
-  - `pyenv` - Cleanup **Pyenv-VirtualEnv** Cache
-  - `steam` - Remove **Steam** logs and cache
-  - `system_caches` - Clear **System cache**
-  - `system_log` - Clear **System Log** Files
-  - `trash` - Empty the **Trash** on All Mounted Volumes and the Main HDD
-  - `wget_logs` - Remove **Wget** logs and hosts
-  - `xcode` - Cleanup **Xcode Derived Data** and **Archives**
-  - `xcode_simulators` - Reset **iOS simulators**
-  - `yarn` - Cleanup **yarn** Cache
-  - `telegram` - Clear old **Telegram** Cache
+- `adobe` - Clears **Adobe** cache files
+- `android` - Clears **Android** caches
+- `brew` - Clears **Homebrew** cache
+- `bun` - Clears **Bun** cache
+- `cacher` - Clears **Cacher** logs
+- `chrome` - Clears **Google Chrome** cache
+- `chromium` - Clears **Chromium** cache files
+- `composer` - Clears **composer** cache
+- `conan` - Clears **Conan** cache
+- `docker` - Cleanup dangling **Docker** Images and stopped containers
+- `dns_cache` - Clears **DNS** cache
+- `dropbox` - Clears **Dropbox** cache
+- `ea` - Clears **EA App** cache files
+- `gem` - Cleanup any old versions of **Gems**
+- `go` - Clears **Go** cache
+- `google_drive` - Clears **Google Drive** caches
+- `gradle` - Clears **Gradle** caches
+- `inactive_memory` - Purge **Inactive Memory**
+- `ios_apps` - Cleanup **iOS Applications**
+- `ios_backups` - Removes **iOS Device Backups**
+- `java_cache` - Removes **Java head dumps** from home directory
+- `jetbrains` - Removes logs from **PhpStorm**, **PyCharm** etc
+- `kite` - Deletes **Kite** logs
+- `lunarclient` - Removes **Lunar Client** logs and cache
+- `minecraft` - Remove **Minecraft** logs and cache
+- `microsoft_teams` - Remove **Microsoft Teams** logs and cache
+- `npm` - Cleanup **npm** Cache
+- `obsidian` - Clears **Obsidian** cache files
+- `nuget` - Clears **.nuget** package files
+- `pnpm` - Cleanup **pnpm** Cache
+- `pod` - Cleanup **CocoaPods** Cache Files
+- `poetry` - Clears **Poetry** cache
+- `pyenv` - Cleanup **Pyenv-VirtualEnv** Cache
+- `steam` - Remove **Steam** logs and cache
+- `system_caches` - Clear **System cache**
+- `system_log` - Clear **System Log** Files
+- `telegram` - Clear old **Telegram** Cache
+- `trash` - Empty the **Trash** on All Mounted Volumes and the Main HDD
+- `wget_logs` - Remove **Wget** logs and hosts
+- `xcode` - Cleanup **Xcode Derived Data** and **Archives**
+- `xcode_simulators` - Reset **iOS simulators**
+- `yarn` - Cleanup **yarn** Cache
 
 </details>
-
-
 
 ## 📥 Installation
 
@@ -123,16 +124,18 @@ options:
 
 ```
 
-
 ## 🌟 Contributing
+
 Contributions are always welcome!\
 If you have any ideas, suggestions, or bug reports, feel free to submit an issue or open a pull request.
 
 ## 📝 License
+
 This project is licensed under the [Apache-2.0 License](https://github.com/mac-cleanup/mac-cleanup-py/blob/main/LICENSE).
 
 ## 👏 Acknowledgements
-This project is developed using tools provided by the *JetBrains OSS Development Program*.
+
+This project is developed using tools provided by the _JetBrains OSS Development Program_.
 
 > Find out more about their program and how they support open source [here](https://jb.gg/OpenSourceSupport).
 

--- a/mac_cleanup/default_modules.py
+++ b/mac_cleanup/default_modules.py
@@ -168,6 +168,7 @@ def minecraft():
             unit.add(Path("~/Library/Application Support/minecraft/crash-reports"))
             unit.add(Path("~/Library/Application Support/minecraft/*.log"))
             unit.add(Path("~/Library/Application Support/minecraft/launcher_cef_log.txt"))
+            unit.add(Path("~/Library/Application Support/minecraft/command_history.txt"))
 
             if check_exists("~/Library/Application Support/minecraft/.mixin.out"):
                 unit.add(Path("~/Library/Application Support/minecraft/.mixin.out"))
@@ -454,3 +455,45 @@ def conan():
         unit.add(Command("""conan remove "*" -c"""))
         unit.add(Path("~/.conan2/p/"))
     
+
+def nuget_cache():
+    with clc as unit:
+        unit.message("Emptying the .nuget folder's content of the current user")
+        unit.add(
+            Path("~/.nuget/packages/").with_prompt(
+                "Deletion of nuget packages will eventually cause a long/big redownloaded!\n" "Continue?"
+            )
+        )
+
+
+def obsidian_caches():
+    with clc as unit:
+        unit.message("Deleting all cache folders of Obsidian.")
+        unit.add(Path("~/Library/Application Support/obsidian/Cache/"))
+        unit.add(Path("~/Library/Application Support/obsidian/Code Cache/"))
+        unit.add(Path("~/Library/Application Support/obsidian/DawnGraphiteCache/"))
+        unit.add(Path("~/Library/Application Support/obsidian/DawnWebGPUCache/"))
+        unit.add(Path("~/Library/Application Support/obsidian/DawnWebGPUCache/"))
+        unit.add(Path("~/Library/Application Support/obsidian/*.log"))
+
+
+def ea_caches():
+    with clc as unit:
+        unit.message("Deleting all cache folders of the EA App.")
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/IGOCache/"))
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/Logs/"))
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/OfflineCache/"))
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/Cache/"))
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/Code Cache/"))
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/DawnCache/"))
+        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/GPUCache/"))
+
+
+def chromium_caches():
+    with clc as unit:
+        unit.message("Deleting all cache folders of chromium.")
+        unit.add(Path("~/Library/Application Support/Chromium/GraphiteDawnCache/"))
+        unit.add(Path("~/Library/Application Support/Chromium/GrShaderCache/"))
+        unit.add(Path("~/Library/Application Support/Chromium/ShaderCache/"))
+        unit.add(Path("~/Library/Application Support/Chromium/Default/DawnCache/"))
+        unit.add(Path("~/Library/Application Support/Chromium/Default/GPUCache/"))


### PR DESCRIPTION
Added the cache and/or log files of following applications: nuget, obsidian, ea app, chromium, freetube, yaaglos, blizzard (deletion of old versions = possible huge space recovery) and added one file for minecraft.

Additional default modules
---

Description
---

_Briefly describe the changes in this pull request._

#### Added following modules:
- nuget folder (microsoft c# packages, should only force redownload when needed)
- obsidian folders
- ea app folders
- chromium folders
- freetube folders
- yet another anime game launcher (genshin) folders
- added a file to the minecraft cleaning
- blizzard battlenet folders and old version folders (which can take up a lot of space.. because blizzard..)

Type of Change
---

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update (I added the items to the readme)

How Has This Been Tested?
---

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] poetry run tox with Python 3.10.14
- [X]  Functional test on local machine

Checklist
---

- [?] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have used Conventional Commits for my commit messages
- [X] New and existing unit tests pass locally with my changes

Screenshots
---

*Screenshots would be too long*

<details>
<summary>The changes as text, formatted with code formatting:</summary>

```
def microsoft_nuget_cache():
    with clc as unit:
        unit.message("Emptying the .nuget folder's content of the current user")
        unit.add(
            Path("~/.nuget/packages/").with_prompt(
                "Deletion of nuget packages will eventually cause a long/big redownloaded!\n" "Continue?"
            )
        )


def obsidian_caches():
    with clc as unit:
        unit.message("Deleting all cache folders of Obsidian.")
        unit.add(Path("~/Library/Application Support/obsidian/Cache/"))
        unit.add(Path("~/Library/Application Support/obsidian/Code Cache/"))
        unit.add(Path("~/Library/Application Support/obsidian/DawnGraphiteCache/"))
        unit.add(Path("~/Library/Application Support/obsidian/DawnWebGPUCache/"))
        unit.add(Path("~/Library/Application Support/obsidian/DawnWebGPUCache/"))
        unit.add(Path("~/Library/Application Support/obsidian/*.log"))


def electronicarts_caches():
    with clc as unit:
        unit.message("Deleting all cache folders of the EA App.")
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/IGOCache/"))
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/Logs/"))
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/OfflineCache/"))
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/Cache/"))
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/Code Cache/"))
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/DawnCache/"))
        unit.add(Path("~/Library/Application Support/Electronic Arts/EA app/CEF/BrowserCache/EADesktop/GPUCache/"))


def chromium_caches():
    with clc as unit:
        unit.message("Deleting all cache folders of chromium.")
        unit.add(Path("~/Library/Application Support/Chromium/GraphiteDawnCache/"))
        unit.add(Path("~/Library/Application Support/Chromium/GrShaderCache/"))
        unit.add(Path("~/Library/Application Support/Chromium/ShaderCache/"))
        unit.add(Path("~/Library/Application Support/Chromium/Default/DawnCache/"))
        unit.add(Path("~/Library/Application Support/Chromium/Default/GPUCache/"))


def freetube_caches():
    with clc as unit:
        unit.message("Deleting all cache folders of the FreeTube app.")
        unit.add(Path("~/Library/Application Support/FreeTube/Cache/"))
        unit.add(Path("~/Library/Application Support/FreeTube/Code Cache/"))
        unit.add(Path("~/Library/Application Support/FreeTube/DawnCache/"))
        unit.add(Path("~/Library/Application Support/FreeTube/DawnGraphiteCache/"))
        unit.add(Path("~/Library/Application Support/FreeTube/DawnWebGPUCache/"))
        unit.add(Path("~/Library/Application Support/FreeTube/player_cache/"))


def yaaglos_genshin_logs():
    with clc as unit:
        unit.message("Cleaning the logs of the Yet another anime game launcher (Yaagl)")
        unit.add(Path("~/Library/Application Support/Yaagl OS/logs/"))
        unit.add(Path("~/Library/Application Support/Yaagl OS/*.log"))


def blizzard_battlenet():
    with clc as unit:
        from mac_cleanup.utils import get_old_battlenet_version_folders

        unit.message("Removing logs, caches and older versions of Battle.net")
        unit.add(Path("~/Library/Application Support/Battle.net/Telemetry/device.txt"))
        unit.add(Path("~/Library/Application Support/Battle.net/BrowserCaches/"))
        unit.add(Path("~/Library/Application Support/Battle.net/Logs/"))

        battlenet_versions = get_old_battlenet_version_folders("~/Library/Application Support/Battle.net/Versions")
        for old_version in battlenet_versions:
            unit.add(Path(old_version))
```

</details>