### PR TITLE
Added verbose argument to print all folders to be deleted

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ options:
   -c, --configure    Open module configuration screen
   -p, --custom-path  Specify path for custom modules
   -f, --force        Accept all warnings
+  -v, --verbose      Print folders to be deleted
 
 ```
 

--- a/mac_cleanup/main.py
+++ b/mac_cleanup/main.py
@@ -19,7 +19,7 @@ class EntryPoint:
         else:
             self.config_path = Path.home().joinpath(".mac_cleanup_py")
 
-        self.base_collector = _Collector()
+        self.base_collector = _Collector(args.verbose)
 
     @staticmethod
     def count_free_space() -> float:

--- a/mac_cleanup/parser.py
+++ b/mac_cleanup/parser.py
@@ -16,6 +16,7 @@ class Args:
     configure: bool = attr.ib(default=False)
     custom_path: bool = attr.ib(default=False)
     force: bool = attr.ib(default=False)
+    verbose: bool = attr.ib(default=False)
 
 
 parser = ArgumentParser(
@@ -37,6 +38,8 @@ parser.add_argument("-p", "--custom-path", help="Specify path for custom modules
 
 parser.add_argument("-f", "--force", help="Accept all warnings", action="store_true")
 
+parser.add_argument("-v", "--verbose", help="Print folders to be deleted", action="store_true")
+
 args = Args()
 parser.parse_args(namespace=args)
 
@@ -44,3 +47,4 @@ parser.parse_args(namespace=args)
 # args.configure = True  # debug
 # args.custom_path = True  # debug
 # args.force = True  # debug
+# args.verbose = True  # debug


### PR DESCRIPTION
Added verbose argument to print all folders to be deleted
---

Description
---

> Use -n -v arguments to check all folders before they will be deleted

- Added print to _get_size method
- Passed verbose argument to _get_size

Type of Change
---

- [x] New feature (non-breaking change which adds functionality)

Checklist
---

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have used Conventional Commits for my commit messages
- [x] New and existing unit tests pass locally with my changes

Additional Context
---

> options:
  -h, --help         show this help message and exit
  -n, --dry-run      Run without deleting stuff
  -u, --update       Update Homebrew on cleanup
  -c, --configure    Open module configuration screen
  -p, --custom-path  Specify path for custom modules
  -f, --force        Accept all warnings
  -v, --verbose      Print folders to be deleted