### PR TITLE
Added a verbose argument to print all folders that will be deleted(refactored)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ options:
   -c, --configure    Open module configuration screen
   -p, --custom-path  Specify path for custom modules
   -f, --force        Accept all warnings
+  -v, --verbose      Print folders to be deleted
 
 ```
 

--- a/mac_cleanup/core.py
+++ b/mac_cleanup/core.py
@@ -192,8 +192,8 @@ class _Collector:
 
         return isinstance(module_, filter_type)
 
-    def _count_dry(self) -> float:
-        """Counts free space for dry run :return: Approx amount of bytes to be removed."""
+    def extract_paths(self) -> (Path_, float):
+        """Extracts all paths from the collector :return: List of paths with size."""
 
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -208,9 +208,6 @@ class _Collector:
         # Extracts paths from path_modules list
         path_list: list[Path_] = [path.get_path for path in path_modules]
 
-        # Set counter for estimated size
-        estimate_size: float = 0
-
         # Get thread executor
         executor = ThreadPoolExecutor()
 
@@ -218,18 +215,34 @@ class _Collector:
             # Add tasks to executor
             tasks = [executor.submit(self._get_size, path) for path in path_list]
 
+            # Store paths and their corresponding futures
+            path_future_map = dict(zip(path_list, tasks))
+
             # Wait for task completion and add ProgressBar
             for future in ProgressBar.wrap_iter(
                 as_completed(tasks), description="Collecting dry run", total=len(path_list)
             ):
-                estimate_size += future.result(timeout=10)
+                path = [p for p, f in path_future_map.items() if f == future][0]
+                size = future.result(timeout=10)
+                yield path, size
         except KeyboardInterrupt:
             # Shutdown executor without waiting for tasks
             executor.shutdown(wait=False)
         else:
             # Cleanup executor
             executor.shutdown(wait=True)
-        return estimate_size
+
+    def _count_dry(self) -> float:
+        """
+        Counts free space for dry run
+        Kept for compatibility with the previous version
+        TODO: Remove in the future
+
+        :return: Approx amount of bytes to be removed.
+
+        """
+
+        return sum([size for _, size in self.extract_paths()])
 
 
 class ProxyCollector:

--- a/mac_cleanup/core.py
+++ b/mac_cleanup/core.py
@@ -236,7 +236,7 @@ class _Collector:
         """
         Counts free space for dry run
         Kept for compatibility with the previous version
-        TODO: Remove in the future
+        TODO: Remove _count_dry as it isn't used anymore
 
         :return: Approx amount of bytes to be removed.
 

--- a/mac_cleanup/main.py
+++ b/mac_cleanup/main.py
@@ -74,7 +74,7 @@ class EntryPoint:
             estimate_size: float = 0
 
             for path, size in self.base_collector.extract_paths():
-                if args.verbose:
+                if args.verbose and size:
                     console.print(bytes_to_human(size), path)
                 estimate_size += size
 

--- a/mac_cleanup/main.py
+++ b/mac_cleanup/main.py
@@ -71,7 +71,14 @@ class EntryPoint:
         if args.dry_run:
             from rich.prompt import Confirm
 
-            freed_space = bytes_to_human(self.base_collector._count_dry())  # noqa
+            estimate_size: float = 0
+
+            for path, size in self.base_collector.extract_paths():
+                if args.verbose:
+                    console.print(bytes_to_human(size), path)
+                estimate_size += size
+
+            freed_space = bytes_to_human(estimate_size)  # noqa
 
             print_panel(text=f"Approx [success]{freed_space}[/success] will be cleaned", title="[info]Dry run results")
 

--- a/mac_cleanup/parser.py
+++ b/mac_cleanup/parser.py
@@ -16,6 +16,7 @@ class Args:
     configure: bool = attr.ib(default=False)
     custom_path: bool = attr.ib(default=False)
     force: bool = attr.ib(default=False)
+    verbose: bool = attr.ib(default=False)
 
 
 parser = ArgumentParser(
@@ -37,6 +38,8 @@ parser.add_argument("-p", "--custom-path", help="Specify path for custom modules
 
 parser.add_argument("-f", "--force", help="Accept all warnings", action="store_true")
 
+parser.add_argument("-v", "--verbose", help="Print folders to be deleted", action="store_true")
+
 args = Args()
 parser.parse_args(namespace=args)
 
@@ -44,3 +47,4 @@ parser.parse_args(namespace=args)
 # args.configure = True  # debug
 # args.custom_path = True  # debug
 # args.force = True  # debug
+# args.verbose = True # debug

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,11 +105,12 @@ class TestEntryPoint:
         assert f"Removed - {size_multiplier / 2} GB" in captured_stdout
 
     @pytest.mark.parametrize("cleanup_prompted", [True, False])
-    def test_dry_run_prompt(self, cleanup_prompted: bool, capsys: CaptureFixture[str], monkeypatch: MonkeyPatch):
-        """Test dry_run with optional cleanup in :class:`mac_cleanup.main.EntryPoint`"""
+    def test_dry_run_prompt(self, cleanup_prompted: bool, capsys: CaptureFixture[str],
+                            monkeypatch: MonkeyPatch):
+        """Test dry_run with verbose and optional cleanup in :class:`mac_cleanup.main.EntryPoint`"""
 
-        # Dummy count_dry returning 1 GB
-        dummy_count_dry: Callable[..., float] = lambda: float(1024**3)
+        # Dummy extract_paths returning [Pathlib("test") and 1 GB]
+        dummy_extract_paths: Callable[..., list[tuple[Pathlib, float]]] = lambda: [(Pathlib("test"), float(1024**3))]
 
         # Dummy Config with empty init
         def dummy_config_init(cfg_self: Config, config_path_: Pathlib) -> None:  # noqa  # noqa
@@ -136,14 +137,17 @@ class TestEntryPoint:
         mock_entry_point = EntryPoint()
         monkeypatch.setattr(EntryPoint, "__new__", lambda: mock_entry_point)
 
-        # Simulate count_dry with predefined result
-        monkeypatch.setattr(mock_entry_point.base_collector, "_count_dry", dummy_count_dry)
+        # Simulate extract_paths with predefined result
+        monkeypatch.setattr(mock_entry_point.base_collector, "extract_paths", dummy_extract_paths)
 
         # Simulate empty cleanup
         monkeypatch.setattr(EntryPoint, "cleanup", dummy_cleanup)
 
         # Simulate dry run was prompted
         monkeypatch.setattr("mac_cleanup.parser.Args.dry_run", True)
+
+        # Simulate verbose was set
+        monkeypatch.setattr("mac_cleanup.parser.Args.verbose", True)
 
         # Call entrypoint
         main()
@@ -155,6 +159,9 @@ class TestEntryPoint:
         assert "Dry run results" in captured_stdout
         assert "Approx 1.0 GB will be cleaned" in captured_stdout
 
+        # Check verbose message
+        assert "1.0 GB test" in captured_stdout
+
         # Check exit message
         if not cleanup_prompted:
             assert "Exiting..." in captured_stdout
@@ -162,8 +169,8 @@ class TestEntryPoint:
     def test_dry_run_prompt_error(self, capsys: CaptureFixture[str], monkeypatch: MonkeyPatch):
         """Test errors in dry_run in :class:`mac_cleanup.main.EntryPoint`"""
 
-        # Dummy count_dry returning 1 GB
-        dummy_count_dry: Callable[..., float] = lambda: float(1024**3)
+        # Dummy extract_paths returning [Pathlib("test") and 1 GB]
+        dummy_extract_paths: Callable[..., list[tuple[Pathlib, float]]] = lambda: [(Pathlib("test"), float(1024**3))]
 
         # Dummy Config with no init and empty call
         # Dummy Config with empty init
@@ -189,8 +196,8 @@ class TestEntryPoint:
         mock_entry_point = EntryPoint()
         monkeypatch.setattr(EntryPoint, "__new__", lambda: mock_entry_point)
 
-        # Simulate count_dry with predefined result
-        monkeypatch.setattr(mock_entry_point.base_collector, "_count_dry", dummy_count_dry)
+        # Simulate extract_paths with predefined result
+        monkeypatch.setattr(mock_entry_point.base_collector, "extract_paths", dummy_extract_paths)
 
         # Simulate dry run was prompted
         monkeypatch.setattr("mac_cleanup.parser.Args.dry_run", True)


### PR DESCRIPTION
Added a verbose argument to print all folders that will be deleted
---

Description
---

Use -n -v arguments to print all folders before they are deleted

- Added the extract_paths method, which returns a list of paths along with their sizes.
- Moved the counting logic from _count_dry to main, with optional printing of folders and their sizes before deletion.
- Marked _count_dry as deprecated

Type of Change
---

- [x] New feature (non-breaking change which adds functionality)

How Has This Been Tested?
---

- [x] Added tests with 100% coverage 

Checklist
---

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have used Conventional Commits for my commit messages
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Additional Context
---

options:
-h, --help show this help message and exit
-n, --dry-run Run without deleting stuff
-u, --update Update Homebrew on cleanup
-c, --configure Open module configuration screen
-p, --custom-path Specify path for custom modules
-f, --force Accept all warnings
-v, --verbose Print folders to be deleted